### PR TITLE
[boot.cmd] add serial port for debugging and access to u-boot

### DIFF
--- a/boot.cmd
+++ b/boot.cmd
@@ -1,4 +1,5 @@
-setenv bootargs earlyprintk no_console_suspend fsck.repair=yes root=/dev/mmcblk0p1 rootfstype=ext4 rootwait init=/lib/systemd/systemd noinitrd panic=10 cma=256M ${extra}
+setenv bootargs earlyprintk no_console_suspend fsck.repair=yes console=ttyS0,115200 root=/dev/mmcblk0p1 rootfstype=ext4 rootwait init=/lib/systemd/systemd noinitrd panic=10 cma=256M ${extra}
+setenv bootdelay 3
 ext4load mmc 0 0x48000000 /boot/uImage
 if gpio input pl11;
 then


### PR DESCRIPTION
The bootdelay is so that if one is connected to the serial port they can access u-boot menu and commands.